### PR TITLE
Add the `./configure --save` flag to `q-e-sirius`

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -174,7 +174,12 @@ class QESirius(Package):
     def install(self, spec, prefix):
 
         prefix_path = prefix.bin if '@:5.4.0' in spec else prefix
-        options = ['-prefix={0}'.format(prefix_path)]
+
+        # QE configure runs make veryclean by default; --save disables that
+        # which will make dev-build faster
+        options = ['--save']
+
+        options.append('-prefix={0}'.format(prefix_path))
 
         sirius = spec['sirius']
 


### PR DESCRIPTION
To make `spack dev-build` faster